### PR TITLE
dom-if link fixed

### DIFF
--- a/app/3.0/nav.yaml
+++ b/app/3.0/nav.yaml
@@ -181,7 +181,7 @@
     path: /3.0/api/elements/dom-bind
     indent: True
   - title: dom-if.js
-    path: /3.0/api/elements/dom-bind
+    path: /3.0/api/elements/dom-if
     indent: True
   - title: dom-module.js
     path: /3.0/api/elements/dom-module


### PR DESCRIPTION
The link to the dom-if documentation when you'd click in the menu actually would take you to dom-bind, making it impossible to read the docs on dom-if unless you knew the link