### PR TITLE
Update redirects.yaml

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -61,17 +61,14 @@
 - /3.0/docs/api/* /3.0/api/
 - /3.0/toolbox/* /3.0/docs/apps/
 - /3.0/start/* /3.0/docs/
-- /3.0/* /3.0/
 
 - /2.0/docs/api/* /2.0/api/
 - /2.0/toolbox/* /2.0/docs/apps/
 - /2.0/start/* /2.0/docs/
-- /2.0/* /2.0/
 
 - /1.0/docs/api/* /1.0/api/
 - /1.0/toolbox/* /1.0/docs/apps/
 - /1.0/start/* /1.0/docs/
-- /1.0/* /1.0/
 
 # ------------------------------------------------------------------------------
 # Note: keep these for the tests!

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -57,6 +57,22 @@
 - /2.0/toolbox/server /2.0/toolbox/prpl
 - /1.0/about /about
 
+# 3.0 => classic site restructure
+- /3.0/docs/api/* /3.0/api/
+- /3.0/toolbox/* /3.0/docs/apps/
+- /3.0/start/* /3.0/docs/
+- /3.0/* /3.0/
+
+- /2.0/docs/api/* /2.0/api/
+- /2.0/toolbox/* /2.0/docs/apps/
+- /2.0/start/* /2.0/docs/
+- /2.0/* /2.0/
+
+- /1.0/docs/api/* /1.0/api/
+- /1.0/toolbox/* /1.0/docs/apps/
+- /1.0/start/* /1.0/docs/
+- /1.0/* /1.0/
+
 # ------------------------------------------------------------------------------
 # Note: keep these for the tests!
 - /oldpage/ /


### PR DESCRIPTION
Links such as https://polymer-library.polymer-project.org/2.0/docs/api/namespaces/Polymer.Async.animationFrame, which are present in https://polymer-library.polymer-project.org/2.0/api/namespaces/Polymer.Async#namespaces, are broken without this redirect.