### PR TITLE
nav: add `Templatize` and `setLegacyOptimizations`

### DIFF
--- a/app/2.0/nav.yaml
+++ b/app/2.0/nav.yaml
@@ -294,6 +294,9 @@
   - title: Polymer.mixinBehaviors
     path: /2.0/api/#function-Polymer.mixinBehaviors
     indent: True 
+  - title: Polymer.setLegacyOptimizations
+    path: /2.0/api/#function-Polymer.setLegacyOptimizations
+    indent: True 
   - title: Polymer.setPassiveTouchGestures
     path: /2.0/api/#function-Polymer.setPassiveTouchGestures
     indent: True 
@@ -337,5 +340,8 @@
     indent: True 
   - title: Polymer.telemetry
     path: /2.0/api/namespaces/Polymer.telemetry
+    indent: True 
+  - title: Polymer.Templatize
+    path: /2.0/api/namespaces/Polymer.Templatize
     indent: True 
   - endheader: True 


### PR DESCRIPTION
Summary:
These two items are missing from the 2.0 sidebar, so there’s no way to
actually get to the `Polymer.Templatize` documentation other than
hacking the URL for another namespace.

Live page:
<https://polymer-library.polymer-project.org/2.0/api/>

Test Plan:
Checked that all elements, classes, mixins, and functions in the main
body are now present in the nav. Checked that the listed URLs are
correct (under the `https://polymer-library.polymer-project.org` host).

wchargin-branch: nav-missing-items