### PR TITLE
Fix copyright dates.

### DIFF
--- a/app/elements/pw-footer.js
+++ b/app/elements/pw-footer.js
@@ -112,7 +112,7 @@ class PwFooter extends PolymerElement {
           <span class="additional-text">Copyright 2014-2020 The Polymer Project Authors. 
           Code licensed under the
           <a target="_blank" href="http://polymer.github.io/LICENSE.txt">BSD License</a>. 
-          Documentation licensed under CC BY 4.0.
+          Documentation licensed under CC BY 3.0.
           </span>
         </div>
         <div>

--- a/app/elements/pw-footer.js
+++ b/app/elements/pw-footer.js
@@ -109,10 +109,10 @@ class PwFooter extends PolymerElement {
       <div class="copyright layout horizontal">
         <div class="flex">
           Brought to you by <a href="https://www.polymer-project.org">The Polymer Project</a>.  
-          <span class="additional-text">Copyright 2018 The Polymer Project Authors. 
+          <span class="additional-text">Copyright 2014-2020 The Polymer Project Authors. 
           Code licensed under the
           <a target="_blank" href="http://polymer.github.io/LICENSE.txt">BSD License</a>. 
-          Documentation licensed under CC BY 3.0.
+          Documentation licensed under CC BY 4.0.
           </span>
         </div>
         <div>


### PR DESCRIPTION
#3/4. Dates are hardcoded here.  (Also correcting earliest date to first version of the polymer library site--apparently when we rolled out new footer designs, we put the same date in for all the sites :/ )

Staged: https://20200527t140529-dot-polymer-library.uc.r.appspot.com/